### PR TITLE
AEA-3797 use custom field for release notes if it is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,16 @@ publish-pfp-aws-release-notes-int:
 		--payload file:///tmp/payload.json /tmp/out.txt
 	cat /tmp/out.txt
 
+test-publish-pfp-aws-release-notes-int:
+	dev_tag=$$(aws cloudformation describe-stacks --stack-name dev-ci --profile prescription-dev --query "Stacks[0].Tags[?Key=='version'].Value" --output text); \
+	int_tag=$$(aws cloudformation describe-stacks --stack-name int-ci --profile prescription-int --query "Stacks[0].Tags[?Key=='version'].Value" --output text); \
+	echo { \"currentTag\": \"$$int_tag\", \"targetTag\": \"$$dev_tag\", \"repoName\": \"prescriptionsforpatients\", \"targetEnvironment\": \"INT\", \"productName\": \"Prescriptions for Patients AWS layer\", \"releaseNotesPageId\": \"768063755\", \"releaseNotesPageTitle\": \"Current PfP AWS layer release notes - TESTING\" } > /tmp/payload.json
+	aws lambda invoke \
+		--function-name "release-notes$${pull_request}-createReleaseNotes" \
+		--cli-binary-format raw-in-base64-out \
+		--payload file:///tmp/payload.json /tmp/out.txt
+	cat /tmp/out.txt
+
 publish-pfp-aws-rc-release-notes-int:
 	dev_tag=$$(aws cloudformation describe-stacks --stack-name dev-ci --profile prescription-dev --query "Stacks[0].Tags[?Key=='version'].Value" --output text); \
 	int_tag=$$(aws cloudformation describe-stacks --stack-name int-ci --profile prescription-int --query "Stacks[0].Tags[?Key=='version'].Value" --output text); \
@@ -46,6 +56,16 @@ publish-pfp-apigee-release-notes-int:
 	dev_tag=$$(curl -s "https://internal-dev.api.service.nhs.uk/prescriptions-for-patients/_ping" | jq --raw-output ".version"); \
 	int_tag=$$(curl -s "https://int.api.service.nhs.uk/prescriptions-for-patients/_ping" | jq --raw-output ".version"); \
 	echo { \"currentTag\": \"$$int_tag\", \"targetTag\": \"$$dev_tag\", \"repoName\": \"prescriptions-for-patients\", \"targetEnvironment\": \"INT\", \"productName\": \"Prescriptions for Patients Apigee layer\", \"releaseNotesPageId\": \"693750035\", \"releaseNotesPageTitle\": \"Current PfP Apigee layer release notes - INT\" } > /tmp/payload.json
+	aws lambda invoke \
+		--function-name "release-notes$${pull_request}-createReleaseNotes" \
+		--cli-binary-format raw-in-base64-out \
+		--payload file:///tmp/payload.json /tmp/out.txt
+	cat /tmp/out.txt
+
+test-publish-pfp-apigee-release-notes-int:
+	dev_tag=$$(curl -s "https://internal-dev.api.service.nhs.uk/prescriptions-for-patients/_ping" | jq --raw-output ".version"); \
+	int_tag=$$(curl -s "https://int.api.service.nhs.uk/prescriptions-for-patients/_ping" | jq --raw-output ".version"); \
+	echo { \"currentTag\": \"$$int_tag\", \"targetTag\": \"$$dev_tag\", \"repoName\": \"prescriptions-for-patients\", \"targetEnvironment\": \"INT\", \"productName\": \"Prescriptions for Patients Apigee layer\", \"releaseNotesPageId\": \"768063758\", \"releaseNotesPageTitle\": \"Current PfP Apigee layer release notes - TESTING\" } > /tmp/payload.json
 	aws lambda invoke \
 		--function-name "release-notes$${pull_request}-createReleaseNotes" \
 		--cli-binary-format raw-in-base64-out \
@@ -82,6 +102,16 @@ publish-fhir-release-notes-int:
 		--payload file:///tmp/payload.json /tmp/out.txt
 	cat /tmp/out.txt
 
+test-publish-fhir-release-notes-int:
+	dev_tag=$$(curl -s "https://internal-dev.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
+	int_tag=$$(curl -s "https://int.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
+	echo { \"currentTag\": \"$$int_tag\", \"targetTag\": \"$$dev_tag\", \"repoName\": \"electronic-prescription-service-api\", \"targetEnvironment\": \"INT\", \"productName\": \"FHIR API\", \"releaseNotesPageId\": \"734403724\", \"releaseNotesPageTitle\": \"Current FHIR API release notes - TESTING\" } > /tmp/payload.json
+	aws lambda invoke \
+		--function-name "release-notes$${pull_request}-createReleaseNotes" \
+		--cli-binary-format raw-in-base64-out \
+		--payload file:///tmp/payload.json /tmp/out.txt
+	cat /tmp/out.txt
+
 publish-fhir-rc-release-notes-int:
 	dev_tag=$$(curl -s "https://internal-dev.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
 	int_tag=$$(curl -s "https://int.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
@@ -96,6 +126,46 @@ publish-fhir-release-notes-prod:
 	dev_tag=$$(curl -s "https://internal-dev.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
 	prod_tag=$$(curl -s "https://api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
 	echo { \"currentTag\": \"$$prod_tag\", \"targetTag\": \"$$dev_tag\", \"repoName\": \"electronic-prescription-service-api\", \"targetEnvironment\": \"PROD\", \"productName\": \"FHIR API\", \"releaseNotesPageId\": \"587367100\", \"releaseNotesPageTitle\": \"Current FHIR API release notes - PROD\" } > /tmp/payload.json
+	aws lambda invoke \
+		--function-name "release-notes$${pull_request}-createReleaseNotes" \
+		--cli-binary-format raw-in-base64-out \
+		--payload file:///tmp/payload.json /tmp/out.txt
+	cat /tmp/out.txt
+
+publish-account-resources-release-notes-int:
+	dev_tag=$$(curl -s "https://internal-dev.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
+	int_tag=$$(curl -s "https://int.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
+	echo { \"currentTag\": \"$$int_tag\", \"targetTag\": \"$$dev_tag\", \"repoName\": \"electronic-prescription-service-account-resources\", \"targetEnvironment\": \"INT\", \"productName\": \"AWS account resources\", \"releaseNotesPageId\": \"749733665\", \"releaseNotesPageTitle\": \"Current AWS account resources release notes - INT\" } > /tmp/payload.json
+	aws lambda invoke \
+		--function-name "release-notes$${pull_request}-createReleaseNotes" \
+		--cli-binary-format raw-in-base64-out \
+		--payload file:///tmp/payload.json /tmp/out.txt
+	cat /tmp/out.txt
+
+test-publish-account-resources-release-notes-int:
+	dev_tag=$$(curl -s "https://internal-dev.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
+	int_tag=$$(curl -s "https://int.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
+	echo { \"currentTag\": \"$$int_tag\", \"targetTag\": \"$$dev_tag\", \"repoName\": \"electronic-prescription-service-account-resources\", \"targetEnvironment\": \"INT\", \"productName\": \"AWS account resources\", \"releaseNotesPageId\": \"768063770\", \"releaseNotesPageTitle\": \"Current AWS account resources release notes - TESTING\" } > /tmp/payload.json
+	aws lambda invoke \
+		--function-name "release-notes$${pull_request}-createReleaseNotes" \
+		--cli-binary-format raw-in-base64-out \
+		--payload file:///tmp/payload.json /tmp/out.txt
+	cat /tmp/out.txt
+
+publish-account-resources-rc-release-notes-int:
+	dev_tag=$$(curl -s "https://internal-dev.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
+	int_tag=$$(curl -s "https://int.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
+	echo { \"createReleaseCandidate\": \"true\", \"releasePrefix\": \"AWS-account-resources-\", \"currentTag\": \"$$int_tag\", \"targetTag\": \"$$dev_tag\", \"repoName\": \"electronic-prescription-service-account-resources\", \"targetEnvironment\": \"INT\", \"productName\": \"AWS account resources\", \"releaseNotesPageId\": \"749733675\", \"releaseNotesPageTitle\": \"FHIR-$$dev_tag - Deployed to [INT] on $$(date +'%d-%m-%y')\" } > /tmp/payload.json
+	aws lambda invoke \
+		--function-name "release-notes$${pull_request}-createReleaseNotes" \
+		--cli-binary-format raw-in-base64-out \
+		--payload file:///tmp/payload.json /tmp/out.txt
+	cat /tmp/out.txt
+
+publish-account-resources-release-notes-prod:
+	dev_tag=$$(curl -s "https://internal-dev.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
+	prod_tag=$$(curl -s "https://api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
+	echo { \"currentTag\": \"$$prod_tag\", \"targetTag\": \"$$dev_tag\", \"repoName\": \"electronic-prescription-service-account-resources\", \"targetEnvironment\": \"PROD\", \"productName\": \"AWS account resources\", \"releaseNotesPageId\": \"749733670\", \"releaseNotesPageTitle\": \"Current FHIR API release notes - PROD\" } > /tmp/payload.json
 	aws lambda invoke \
 		--function-name "release-notes$${pull_request}-createReleaseNotes" \
 		--cli-binary-format raw-in-base64-out \

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ test-publish-account-resources-release-notes-int:
 publish-account-resources-rc-release-notes-int:
 	dev_tag=$$(curl -s "https://internal-dev.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
 	int_tag=$$(curl -s "https://int.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
-	echo { \"createReleaseCandidate\": \"true\", \"releasePrefix\": \"AWS-account-resources-\", \"currentTag\": \"$$int_tag\", \"targetTag\": \"$$dev_tag\", \"repoName\": \"electronic-prescription-service-account-resources\", \"targetEnvironment\": \"INT\", \"productName\": \"AWS account resources\", \"releaseNotesPageId\": \"749733675\", \"releaseNotesPageTitle\": \"FHIR-$$dev_tag - Deployed to [INT] on $$(date +'%d-%m-%y')\" } > /tmp/payload.json
+	echo { \"createReleaseCandidate\": \"true\", \"releasePrefix\": \"AWS-account-resources-\", \"currentTag\": \"$$int_tag\", \"targetTag\": \"$$dev_tag\", \"repoName\": \"electronic-prescription-service-account-resources\", \"targetEnvironment\": \"INT\", \"productName\": \"AWS account resources\", \"releaseNotesPageId\": \"749733675\", \"releaseNotesPageTitle\": \"AWS-account-resources-$$dev_tag - Deployed to [INT] on $$(date +'%d-%m-%y')\" } > /tmp/payload.json
 	aws lambda invoke \
 		--function-name "release-notes$${pull_request}-createReleaseNotes" \
 		--cli-binary-format raw-in-base64-out \
@@ -165,7 +165,7 @@ publish-account-resources-rc-release-notes-int:
 publish-account-resources-release-notes-prod:
 	dev_tag=$$(curl -s "https://internal-dev.api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
 	prod_tag=$$(curl -s "https://api.service.nhs.uk/electronic-prescriptions/_ping" | jq --raw-output ".version"); \
-	echo { \"currentTag\": \"$$prod_tag\", \"targetTag\": \"$$dev_tag\", \"repoName\": \"electronic-prescription-service-account-resources\", \"targetEnvironment\": \"PROD\", \"productName\": \"AWS account resources\", \"releaseNotesPageId\": \"749733670\", \"releaseNotesPageTitle\": \"Current FHIR API release notes - PROD\" } > /tmp/payload.json
+	echo { \"currentTag\": \"$$prod_tag\", \"targetTag\": \"$$dev_tag\", \"repoName\": \"electronic-prescription-service-account-resources\", \"targetEnvironment\": \"PROD\", \"productName\": \"AWS account resources\", \"releaseNotesPageId\": \"749733670\", \"releaseNotesPageTitle\": \"Current AWS account resources release notes - PROD\" } > /tmp/payload.json
 	aws lambda invoke \
 		--function-name "release-notes$${pull_request}-createReleaseNotes" \
 		--cli-binary-format raw-in-base64-out \

--- a/README.md
+++ b/README.md
@@ -196,15 +196,30 @@ By default these all run against the deployed lambdas from the main branch. If y
 export pull_request=-pr-27
 ```
 
-- `publish-pfp-aws-release-notes-int` Updates release notes for pfp AWS layer comparing what is currently in int to what is currently in dev
-- `publish-pfp-aws-rc-release-notes-int` Creates release notes for pfp AWS layer comparing what is currently in int to what is currently in dev. Also creates a release in jira and adds fix version to jira tickets found
-- `publish-pfp-aws-release-notes-prod` Updates release notes for pfp AWS layer comparing what is currently in prod to what is currently in dev
-- `publish-pfp-apigee-release-notes-int` Updates release notes for pfp Apigee layer comparing what is currently in int to what is currently in dev
-- `publish-pfp-apigee-rc-release-notes-int` Creates release notes for pfp Apigee layer comparing what is currently in int to what is currently in dev. Also creates a release in jira and adds fix version to jira tickets found
-- `publish-pfp-apigee-release-notes-prod` Creates release notes for pfp Apigee layer comparing what is currently in prod to what is currently in dev
-- `publish-fhir-release-notes-int` Updates release notes for FHIR api comparing what is currently in int to what is currently in dev
-- `publish-fhir-rc-release-notes-int` Creates release notes for FHIR api comparing what is currently in int to what is currently in dev. Also creates a release in jira and adds fix version to jira tickets found
-- `publish-fhir-release-notes-prod` Creates release notes for FHIR api comparing what is currently in prod to what is currently in dev
+You must also set environment variables dev_tag, int_tag, prod_tag.
+
+**THE RC RELEASE NOTES CALLS ALSO MODIFY TICKETS IN JIRA BY CHANGING STATUS AND ADDING A FIX SO SHOULD BE USED CAREFULLY**
+
+- `publish-pfp-aws-release-notes-int` Updates release notes for pfp AWS layer showing what is between int_tag and dev_tag
+- `publish-pfp-aws-rc-release-notes-int` Creates release notes for pfp AWS layer showing what is between int_tag and dev_tag. Also creates a release in jira and adds fix version to jira tickets found
+- `publish-pfp-aws-release-notes-prod` Updates release notes for pfp AWS layer showing what is between prod_tag and dev_tag
+- `test-publish-pfp-aws-release-notes-int` Updates test release notes in testing location for pfp AWS layer showing what is between int_tag and dev_tag
+
+- `publish-pfp-apigee-release-notes-int` Updates release notes for pfp Apigee layer showing what is between int_tag and dev_tag
+- `publish-pfp-apigee-rc-release-notes-int` Creates release notes for pfp Apigee layer showing what is between int_tag and dev_tag. Also creates a release in jira and adds fix version to jira tickets found
+- `publish-pfp-apigee-release-notes-prod` Creates release notes for pfp Apigee layer showing what is between prod_tag and dev_tag
+- `test-publish-pfp-apigee-release-notes-int` Updates test release notes in testing location for pfp Apigee layer showing what is between int_tag and dev_tag
+
+- `publish-fhir-release-notes-int` Updates release notes for FHIR api showing what is between int_tag and dev_tag
+- `publish-fhir-rc-release-notes-int` Creates release notes for FHIR api showing what is between int_tag and dev_tag. Also creates a release in jira and adds fix version to jira tickets found
+- `publish-fhir-release-notes-prod` Creates release notes for FHIR api showing what is between prod_tag and dev_tag
+- `publish-fhir-release-notes-int` Updates test release notes in testing location for FHIR api showing what is between int_tag and dev_tag
+
+- `publish-account-resources-release-notes-int` Updates release notes for FHIR api showing what is between int_tag and dev_tag
+- `publish-account-resources-rc-release-notes-int` Creates release notes for FHIR api showing what is between int_tag and dev_tag. Also creates a release in jira and adds fix version to jira tickets found
+- `publish-account-resources-release-notes-prod` Creates release notes for FHIR api showing what is between prod_tag and dev_tag
+- `publish-account-resources-release-notes-int` Updates test release notes in testing location for FHIR api showing what is between int_tag and dev_tag
+
 - `mark-jira-released` Marks a jira version as released
 
 ### Github folder

--- a/create_release_notes/create_release_notes.py
+++ b/create_release_notes/create_release_notes.py
@@ -132,18 +132,17 @@ def get_jira_details(jira: Jira, jira_ticket_number: str) -> JiraDetails:
         components = [
             component["name"] for component in jira_ticket["fields"]["components"]
         ]
-        user_story = jira_ticket["fields"].get("customfield_17101")
-        if user_story is None:
+        user_story = jira_ticket["fields"].get("customfield_17101", "").strip()
+        if user_story == "":
             match = match = re.search(
                 r"(user story)(.*?)background",
                 jira_description,
                 re.IGNORECASE | re.MULTILINE | re.DOTALL,
             )
             if match:
-                user_story = match.group(2).replace("*", "").replace("h3.", "")
+                user_story = match.group(2).replace("*", "").replace("h3.", "").strip()
             else:
                 user_story = "can not find user story"
-        user_story = user_story.strip()
         impact_field = jira_ticket.get("fields", {}).get("customfield_26905", {})
         if impact_field:
             impact = impact_field.get("value", "")

--- a/create_release_notes/create_release_notes.py
+++ b/create_release_notes/create_release_notes.py
@@ -132,15 +132,18 @@ def get_jira_details(jira: Jira, jira_ticket_number: str) -> JiraDetails:
         components = [
             component["name"] for component in jira_ticket["fields"]["components"]
         ]
-        match = match = re.search(
-            r"(user story)(.*?)background",
-            jira_description,
-            re.IGNORECASE | re.MULTILINE | re.DOTALL,
-        )
-        if match:
-            user_story = match.group(2).replace("*", "").replace("h3.", "").strip()
-        else:
-            user_story = "can not find user story"
+        user_story = jira_ticket["fields"].get("customfield_17101")
+        if user_story is None:
+            match = match = re.search(
+                r"(user story)(.*?)background",
+                jira_description,
+                re.IGNORECASE | re.MULTILINE | re.DOTALL,
+            )
+            if match:
+                user_story = match.group(2).replace("*", "").replace("h3.", "")
+            else:
+                user_story = "can not find user story"
+        user_story = user_story.strip()
         impact_field = jira_ticket.get("fields", {}).get("customfield_26905", {})
         if impact_field:
             impact = impact_field.get("value", "")

--- a/create_release_notes/create_release_notes.py
+++ b/create_release_notes/create_release_notes.py
@@ -132,17 +132,18 @@ def get_jira_details(jira: Jira, jira_ticket_number: str) -> JiraDetails:
         components = [
             component["name"] for component in jira_ticket["fields"]["components"]
         ]
-        user_story = jira_ticket["fields"].get("customfield_17101", "").strip()
-        if user_story == "":
+        user_story = jira_ticket["fields"].get("customfield_17101")
+        if user_story is None or user_story == "":
             match = match = re.search(
                 r"(user story)(.*?)background",
                 jira_description,
                 re.IGNORECASE | re.MULTILINE | re.DOTALL,
             )
             if match:
-                user_story = match.group(2).replace("*", "").replace("h3.", "").strip()
+                user_story = match.group(2).replace("*", "").replace("h3.", "")
             else:
                 user_story = "can not find user story"
+        user_story = user_story.strip()
         impact_field = jira_ticket.get("fields", {}).get("customfield_26905", {})
         if impact_field:
             impact = impact_field.get("value", "")

--- a/tests/common.py
+++ b/tests/common.py
@@ -31,6 +31,17 @@ def mocked_jira_get_issue(*args, **kwargs):
                 "customfield_13618": "Service Impact",
             }
         }
+    elif args[0] == "AEA-126":
+        return {
+            "fields": {
+                "summary": "Test Summary",
+                "description": "User story\nit should not use this user story\nBackground: Test Background",
+                "components": [{"name": "Component1"}, {"name": "Component2"}],
+                "customfield_26905": {"value": "High"},
+                "customfield_13618": "Service Impact",
+                "customfield_17101": "This is the user story that should be used\nover two lines",
+            }
+        }
     else:
         raise (Exception)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -42,6 +42,28 @@ def mocked_jira_get_issue(*args, **kwargs):
                 "customfield_17101": "This is the user story that should be used\nover two lines",
             }
         }
+    elif args[0] == "AEA-127":
+        return {
+            "fields": {
+                "summary": "Test Summary",
+                "description": "User story\nit should use this user story\nBackground: Test Background",
+                "components": [{"name": "Component1"}, {"name": "Component2"}],
+                "customfield_26905": {"value": "High"},
+                "customfield_13618": "Service Impact",
+                "customfield_17101": "",
+            }
+        }
+    elif args[0] == "AEA-128":
+        return {
+            "fields": {
+                "summary": "Test Summary",
+                "description": "User story\nit should use this user story\nBackground: Test Background",
+                "components": [{"name": "Component1"}, {"name": "Component2"}],
+                "customfield_26905": {"value": "High"},
+                "customfield_13618": "Service Impact",
+                "customfield_17101": None,
+            }
+        }
     else:
         raise (Exception)
 

--- a/tests/test_create_release_notes_get_jira_details.py
+++ b/tests/test_create_release_notes_get_jira_details.py
@@ -18,7 +18,7 @@ class TestGetJiraDetails(unittest.TestCase):
         self.assertEqual(jira_details.business_service_impact, "Service Impact")
 
     @patch("create_release_notes.create_release_notes.Jira")
-    def test_get_jira_details_user_story_seperate_field(self, mock_jira):
+    def test_get_jira_details_user_story_separate_field_populated(self, mock_jira):
         mock_jira.get_issue.side_effect = mocked_jira_get_issue
 
         jira_details = create_release_notes.get_jira_details(mock_jira, "AEA-126")
@@ -27,6 +27,36 @@ class TestGetJiraDetails(unittest.TestCase):
         self.assertEqual(
             jira_details.user_story,
             "This is the user story that should be used\nover two lines",
+        )
+        self.assertEqual(jira_details.components, ["Component1", "Component2"])
+        self.assertEqual(jira_details.impact, "High")
+        self.assertEqual(jira_details.business_service_impact, "Service Impact")
+
+    @patch("create_release_notes.create_release_notes.Jira")
+    def test_get_jira_details_user_story_separate_field_blank(self, mock_jira):
+        mock_jira.get_issue.side_effect = mocked_jira_get_issue
+
+        jira_details = create_release_notes.get_jira_details(mock_jira, "AEA-127")
+
+        self.assertEqual(jira_details.jira_title, "Test Summary")
+        self.assertEqual(
+            jira_details.user_story,
+            "it should use this user story",
+        )
+        self.assertEqual(jira_details.components, ["Component1", "Component2"])
+        self.assertEqual(jira_details.impact, "High")
+        self.assertEqual(jira_details.business_service_impact, "Service Impact")
+
+    @patch("create_release_notes.create_release_notes.Jira")
+    def test_get_jira_details_user_story_separate_field_none(self, mock_jira):
+        mock_jira.get_issue.side_effect = mocked_jira_get_issue
+
+        jira_details = create_release_notes.get_jira_details(mock_jira, "AEA-128")
+
+        self.assertEqual(jira_details.jira_title, "Test Summary")
+        self.assertEqual(
+            jira_details.user_story,
+            "it should use this user story",
         )
         self.assertEqual(jira_details.components, ["Component1", "Component2"])
         self.assertEqual(jira_details.impact, "High")

--- a/tests/test_create_release_notes_get_jira_details.py
+++ b/tests/test_create_release_notes_get_jira_details.py
@@ -18,6 +18,21 @@ class TestGetJiraDetails(unittest.TestCase):
         self.assertEqual(jira_details.business_service_impact, "Service Impact")
 
     @patch("create_release_notes.create_release_notes.Jira")
+    def test_get_jira_details_user_story_seperate_field(self, mock_jira):
+        mock_jira.get_issue.side_effect = mocked_jira_get_issue
+
+        jira_details = create_release_notes.get_jira_details(mock_jira, "AEA-126")
+
+        self.assertEqual(jira_details.jira_title, "Test Summary")
+        self.assertEqual(
+            jira_details.user_story,
+            "This is the user story that should be used\nover two lines",
+        )
+        self.assertEqual(jira_details.components, ["Component1", "Component2"])
+        self.assertEqual(jira_details.impact, "High")
+        self.assertEqual(jira_details.business_service_impact, "Service Impact")
+
+    @patch("create_release_notes.create_release_notes.Jira")
     def test_get_jira_details_no_user_story(self, mock_jira):
         mock_jira.get_issue.side_effect = mocked_jira_get_issue
 
@@ -45,10 +60,10 @@ class TestGetJiraDetails(unittest.TestCase):
     def test_get_jira_details_exception(self, mock_jira):
         mock_jira.get_issue.side_effect = mocked_jira_get_issue
 
-        jira_details = create_release_notes.get_jira_details(mock_jira, "AEA-126")
+        jira_details = create_release_notes.get_jira_details(mock_jira, "AEA-unknown")
 
         self.assertEqual(
-            jira_details.jira_title, "can not find jira ticket for AEA-126"
+            jira_details.jira_title, "can not find jira ticket for AEA-unknown"
         )
         self.assertEqual(jira_details.user_story, "")
         self.assertEqual(jira_details.components, [])


### PR DESCRIPTION
## Summary

- Routine Change


### Details

- use new custom field for user story in release notes if it is populated
- added Makefile targets to create account resources release notes
- update README